### PR TITLE
Insurance atHome delivery method not working

### DIFF
--- a/bpost.php
+++ b/bpost.php
@@ -1813,8 +1813,8 @@ class bPostDeliveryMethodAtHome extends bPostDeliveryMethod
 		}
 		if($this->insurance !== null)
 		{
-			if($this->insurance == 0) $data['atHome']['insurance']['basicInsurance'] = '';
-			else $data['atHome']['insurance']['additionalInsurance']['@attributes']['value'] = $this->insurance;
+			if($this->insurance == 0) $data['atHome']['insured']['basicInsurance'] = '';
+			else $data['atHome']['insured']['additionalInsurance']['@attributes']['value'] = $this->insurance;
 		}
 		if($this->dropAtTheDoor) $data['atHome']['dropAtTheDoor'] = null;
 


### PR DESCRIPTION
Due to a typo 'atHome-7' instead of 'atHome' and misnamed field 'insurance' (should be 'insured') the atHome delivery method is not working.

Please accept this fix, so I can use your repo master version again.
