### PR TITLE
Allowed SaturdayDelivery option on national boxes

### DIFF
--- a/Bpost/Order/Box/Option/SaturdayDelivery.php
+++ b/Bpost/Order/Box/Option/SaturdayDelivery.php
@@ -1,0 +1,33 @@
+<?php
+namespace TijsVerkoyen\Bpost\Bpost\Order\Box\Option;
+
+use DOMDocument;
+use DomElement;
+
+/**
+ * bPost SaturdayDelivery class
+ *
+ * @author    Tijs Verkoyen <php-bpost@verkoyen.eu>
+ * @version   3.0.0
+ * @copyright Copyright (c), Tijs Verkoyen. All rights reserved.
+ * @license   BSD License
+ */
+class SaturdayDelivery extends Option
+{
+    /**
+     * Return the object as an array for usage in the XML
+     *
+     * @param  DomDocument $document
+     * @param  string      $prefix
+     * @return DomElement
+     */
+    public function toXML(DOMDocument $document, $prefix = 'common')
+    {
+        $tagName = 'saturdayDelivery';
+        if ($prefix !== null) {
+            $tagName = $prefix . ':' . $tagName;
+        }
+
+        return $document->createElement($tagName);
+    }
+}


### PR DESCRIPTION
Checked with BPost employees. They confirmed it produces valid XML output that gets accepted in their testing environment and it is an option for every national delivery type. They only need to finish their stuff and deploy to production.

So just don't use this option. Yet.
