### PR TITLE
Add PRINTED status, and some bonus

### DIFF
--- a/Bpost.php
+++ b/Bpost.php
@@ -211,7 +211,7 @@ class Bpost
 
             if (
                 (isset($headers['content_type']) && substr_count($headers['content_type'], 'text/plain') > 0) ||
-                ($headers['http_code'] == '404')
+                (in_array($headers['http_code'], array(400, 404)))
             ) {
                 $message = $response;
             } else {

--- a/Bpost.php
+++ b/Bpost.php
@@ -381,7 +381,7 @@ class Bpost
      * Modify the status for an order.
      *
      * @param  string $reference The reference for an order
-     * @param  string $status    The new status, allowed values are: OPEN, PENDING, CANCELLED, COMPLETED or ON-HOLD
+     * @param  string $status    The new status, allowed values are: OPEN, PENDING, CANCELLED, COMPLETED, ON-HOLD or PRINTED
      * @return bool
      */
     public function modifyOrderStatus($reference, $status)

--- a/Bpost.php
+++ b/Bpost.php
@@ -93,7 +93,7 @@ class Bpost
      * @param  SimpleXMLElement $item   The item to decode.
      * @param  array            $return Just a placeholder.
      * @param  int              $i      A internal counter.
-     * @return mixed
+     * @return array
      */
     private static function decodeResponse($item, $return = null, $i = 0)
     {
@@ -446,7 +446,7 @@ class Bpost
      * @param  string $format
      * @param  bool   $withReturnLabels
      * @param  bool   $asPdf
-     * @return array
+     * @return Label[]
      */
     protected function getLabel($url, $format = 'A6', $withReturnLabels = false, $asPdf = false)
     {
@@ -502,7 +502,7 @@ class Bpost
      * @param  string $format           The desired format, allowed values are: A4, A6
      * @param  bool   $withReturnLabels Should return labels be returned?
      * @param  bool   $asPdf            Should we retrieve the PDF-version instead of PNG
-     * @return array
+     * @return Label[]
      */
     public function createLabelForOrder($reference, $format = 'A6', $withReturnLabels = false, $asPdf = false)
     {
@@ -518,7 +518,7 @@ class Bpost
      * @param  string $format           The desired format, allowed values are: A4, A6
      * @param  bool   $withReturnLabels Should return labels be returned?
      * @param  bool   $asPdf            Should we retrieve the PDF-version instead of PNG
-     * @return array
+     * @return Label[]
      */
     public function createLabelForBox($barcode, $format = 'A6', $withReturnLabels = false, $asPdf = false)
     {
@@ -537,7 +537,7 @@ class Bpost
      * @param  string $format           The desired format, allowed values are: A4, A6
      * @param  bool   $withReturnLabels Should return labels be returned?
      * @param  bool   $asPdf            Should we retrieve the PDF-version instead of PNG
-     * @return array
+     * @return Label[]
      */
     public function createLabelInBulkForOrders(
         array $references,

--- a/Bpost/Order.php
+++ b/Bpost/Order.php
@@ -66,7 +66,7 @@ class Order
     }
 
     /**
-     * @return array
+     * @return Box[]
      */
     public function getBoxes()
     {
@@ -108,7 +108,7 @@ class Order
     }
 
     /**
-     * @return array
+     * @return Line[]
      */
     public function getLines()
     {

--- a/Bpost/Order/Box.php
+++ b/Bpost/Order/Box.php
@@ -136,7 +136,8 @@ class Box
             'PRINTED',
             'CANCELLED',
             'COMPLETED',
-            'ON-HOLD'
+            'ON-HOLD',
+            'PRINTED'
         );
     }
 

--- a/Bpost/Order/Box/AtHome.php
+++ b/Bpost/Order/Box/AtHome.php
@@ -188,7 +188,7 @@ class AtHome extends National
                 (string) $xml->atHome->product
             );
         }
-        if (isset($xml->atHome->options)) {
+        if (isset($xml->atHome->options) && !empty($xml->atHome->options)) {
             foreach ($xml->atHome->options as $optionData) {
                 $optionData = $optionData->children('http://schema.post.be/shm/deepintegration/v3/common');
 

--- a/Bpost/Order/Box/IBox.php
+++ b/Bpost/Order/Box/IBox.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace TijsVerkoyen\Bpost\Bpost\Order\Box;
+
+interface IBox
+{
+
+    /**
+     * @param array $options
+     */
+    public function setOptions($options);
+
+    /**
+     * @return array
+     */
+    public function getOptions();
+
+    /**
+     * @param \TijsVerkoyen\Bpost\Bpost\Order\Box\Option\Option $option
+     */
+    public function addOption(Option\Option $option);
+
+    /**
+     * @param string $product
+     */
+    public function setProduct($product);
+
+    /**
+     * @return string
+     */
+    public function getProduct();
+
+    /**
+     * @remark should be implemented by the child class
+     * @return array
+     */
+    public static function getPossibleProductValues();
+
+    /**
+     * Return the object as an array for usage in the XML
+     * @param  \DomDocument $document
+     * @param  string $prefix
+     * @return \DomElement
+     */
+    public function toXML(\DOMDocument $document, $prefix = null);
+
+    /**
+     * @param  \SimpleXMLElement $xml
+     * @return self
+     */
+    public static function createFromXML(\SimpleXMLElement $xml);
+}

--- a/Bpost/Order/Box/International.php
+++ b/Bpost/Order/Box/International.php
@@ -13,7 +13,7 @@ use TijsVerkoyen\Bpost\Bpost\Order\Receiver;
  * @copyright Copyright (c), Tijs Verkoyen. All rights reserved.
  * @license   BSD License
  */
-class International
+class International implements IBox
 {
     /**
      * @var string

--- a/Bpost/Order/Box/National.php
+++ b/Bpost/Order/Box/National.php
@@ -9,7 +9,7 @@ namespace TijsVerkoyen\Bpost\Bpost\Order\Box;
  * @copyright Copyright (c), Tijs Verkoyen. All rights reserved.
  * @license   BSD License
  */
-abstract class National
+abstract class National implements IBox
 {
     /**
      * @var string


### PR DESCRIPTION
* Add PRINTED to possible order status values
* If $xml->atHome->options is exists but is empty in XML, we don't loop on (make an error)
* Correct some @return to help the IDE
* HTTP status 400 and 404 (instead 404 only) permit to show the error message