### PR TITLE
If HTTP status is 400 or 404, it shows the error message

### DIFF
--- a/Bpost.php
+++ b/Bpost.php
@@ -211,7 +211,7 @@ class Bpost
 
             if (
                 (isset($headers['content_type']) && substr_count($headers['content_type'], 'text/plain') > 0) ||
-                ($headers['http_code'] == '404')
+                (in_array($headers['http_code'], array(400, 404)))
             ) {
                 $message = $response;
             } else {


### PR DESCRIPTION
HTTP statusses 400 and 404 (instead of 404 only) permit to show the error message