### PR TITLE
Check if options isn't empty

### DIFF
--- a/Bpost/Order/Box/AtHome.php
+++ b/Bpost/Order/Box/AtHome.php
@@ -188,7 +188,7 @@ class AtHome extends National
                 (string) $xml->atHome->product
             );
         }
-        if (isset($xml->atHome->options)) {
+        if (isset($xml->atHome->options) and !empty($xml->atHome->options)) {
             foreach ($xml->atHome->options as $optionData) {
                 $optionData = $optionData->children('http://schema.post.be/shm/deepintegration/v3/common');
 


### PR DESCRIPTION
When a bpost has been created without options, there is still an empty options node returned. In this case the script should not continue to process the options list. 

This small change checks if the options in fact contains any nodes at all.