### PR TITLE
Integration with v3.3.5

### DIFF
--- a/Bpost.php
+++ b/Bpost.php
@@ -1,6 +1,7 @@
 <?php
 namespace TijsVerkoyen\Bpost;
 
+use Exception;
 use TijsVerkoyen\Bpost\Bpost\Label;
 use TijsVerkoyen\Bpost\Bpost\Order;
 use TijsVerkoyen\Bpost\Bpost\Order\Box;

--- a/Bpost/Order/Box.php
+++ b/Bpost/Order/Box.php
@@ -135,8 +135,12 @@ class Box
             'PENDING',
             'PRINTED',
             'CANCELLED',
-            'COMPLETED',
-            'ON-HOLD'
+            'ON-HOLD',
+            'ANNOUNCED',
+            'IN_TRANSIT',
+            'AWAITING_PICKUP',
+            'DELIVERED',
+            'BACK_TO_SENDER',
         );
     }
 


### PR DESCRIPTION
Had some problems with fetching the correct order box status. It kept returning the order status 'PRINTED' but the box was actually already 'DELIVERED'. I contacted Bpost support and they told me to update the accept header to v3.3. It appears to return the wrong value in v3.

It is also mentioned in their latest documentation which can be downloaded here:
http://bpost.freshdesk.com/support/solutions/articles/4000037653-where-can-i-find-the-bpack-integration-manual-examples-and-xsd-s-

On page 194, there is a list of all required webservice headers.