### PR TITLE
fix check curl error code

### DIFF
--- a/src/ApiCaller/ApiCaller.php
+++ b/src/ApiCaller/ApiCaller.php
@@ -97,7 +97,7 @@ class ApiCaller
         ));
 
         // error?
-        if ($errorNumber != '') {
+        if ($errorNumber != 0) {
             throw new BpostCurlException($errorMessage, $errorNumber);
         }
 


### PR DESCRIPTION
[curl_errno](https://www.php.net/manual/fr/function.curl-errno.php) return an integer and not a string 

so an exception is thrown despite of the response is a `201`

![image](https://user-images.githubusercontent.com/14903820/131701429-0b424aa2-1170-442d-8c9d-6d84605f778e.png)

php version 8.0.8